### PR TITLE
Adds Return documentation and adds lubridate to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,5 +12,6 @@ Description: Selectively acquire hourly meteorological data from stations locate
 License: MIT + file LICENSE
 Imports:
     plyr (>= 1.8.2), dplyr (>= 0.4.2),
-    readr (>= 0.1.1), downloader (>= 0.3)
+    readr (>= 0.1.1), downloader (>= 0.3),
+    lubridate
 URL: https://github.com/rich-iannone/stationaRy

--- a/R/get_isd_station_data.R
+++ b/R/get_isd_station_data.R
@@ -10,6 +10,67 @@
 #' @import readr
 #' @import lubridate
 #' @import downloader
+#' 
+#' @return Returns a data frame with 19 variables.  Times are recorded 
+#' using the Universal Time Code (UTC) in the source data.  Using 
+#' \code{local_tz} adjusts the time zone to the current locale.
+#' \describe{
+#'   \item{usaf}{A character string identifying the fixed weather 
+#'     station from the USAF Master Station Catalog.
+#'     USAF is an acronym for United States Air Force.}
+#'   \item{wban}{A character string for the fixed weather
+#'     station NCDC WBAN identifier.  
+#'     NCDC is an acronym for National Climatic Data Center. 
+#'     WBAN is an acronym for Weather Bureau, Air Force and Navy.}
+#'   \item{year}{A numeric, four digit value giving the year of the 
+#'     observation.}
+#'   \item{month}{A numeric value (one or two digits) giving the month
+#'     of the observation.}
+#'   \item{day}{A numeric value (one or two digits) giving the day of the 
+#'     month of the observation.}
+#'   \item{hour}{A numeric value (one or two digits) giving the hour of 
+#'     the observation.}
+#'   \item{minute}{A numeric value (one or two digits) giving the minute 
+#'     of the hour in which the observation was recorded.}
+#'   \item{lat}{Latitude (degrees) rounded to three decimal places.}
+#'   \item{lon}{Longitude (degrees) rounded to three decimal places.}
+#'   \item{elev}{Numeric value for the elevation as measured in meters. 
+#'     The minimum value is -400 with a maximum of 8850. Elevation in feet
+#'     can be approximated by \code{elev * 3.28084}}
+#'   \item{wd}{The angle of wind direction, measured in a clockwise 
+#'     direction, between true north and the direction from which
+#'     the wind is blowing.  For example, \code{wd = 90} indicates the 
+#'     wind is blowing from due east.  \code{wd = 225} indicates the 
+#'     wind is blowing from the south west.  The minimum value is 1, and the
+#'     maximum value is 360.}
+#'   \item{ws}{Wind speed in meters per second.  Wind speed in feet per 
+#'     second can be estimated by \code{ws * 3.28084}}
+#'   \item{ceil_hgt}{The height above ground level of the lowest clould cover
+#'     or other obscuring phenomena amounting to at least 5/8 sky 
+#'     coverate.  Measured in meters.  Unlimited height (no obstruction)
+#'     is denoted by the value 22000}
+#'   \item{temp}{Air temperature measured in degrees Celsius.  Conversions 
+#'     to degrees Farenheit may be calculated with 
+#'     \code{(temp * 9) / 5 + 32}}.
+#'   \item{dew_point}{The temperature in degrees Celsius to which a 
+#'     given parcel of air must be cooled at constant pressure and 
+#'     water vapor content in order for saturation to occur.}
+#'   \item{atmos_pres}{The air pressure in hectopascals relative to 
+#'     Mean Sea Level (MSL)}
+#'   \item{rh}{Relative humidity, measured as a percentage, 
+#'     as calculated using the August-Roche-Magnus approximation}
+#'   \item{time}{A POSIXct object with the date-time of the observation.}
+#'   \item{min}{The minute value of the observation.  This is a duplicate
+#'     of minute.}
+#' }
+#' 
+#' @source 
+#' \url{http://www.ncdc.noaa.gov/isd}\cr
+#' \url{http://www1.ncdc.noaa.gov/pub/data/ish/ish-format-document.pdf}
+#' 
+#' Calculating Humidity: \cr
+#' \url{https://en.wikipedia.org/wiki/Clausius\%E2\%80\%93Clapeyron_relation#Meteorology_and_climatology}
+#' 
 #' @examples 
 #' \dontrun{
 #' # Obtain a listing of all stations within a bounding box and

--- a/R/get_isd_stations.R
+++ b/R/get_isd_stations.R
@@ -10,6 +10,44 @@
 #' @param upper_lon the upper bound of the longitude for a bounding box.
 #' @import downloader
 #' @import dplyr
+#' 
+#' @return Returns a data frame with 15 columns.
+#' \describe{
+#'   \item{usaf}{A character string identifying the fixed weather 
+#'     station from the USAF Master Station Catalog.
+#'     USAF is an acronym for United States Air Force.}
+#'   \item{wban}{A character string for the fixed weather
+#'     station NCDC WBAN identifier.  
+#'     NCDC is an acronym for National Climatic Data Center. 
+#'     WBAN is an acronym for Weather Bureau, Air Force and Navy.}
+#'   \item{name}{A character string with the station name.}
+#'   \item{country}{A character string with the two character country 
+#'     code where the station is located. Not identical to \code{country_code}.}
+#'   \item{state}{Character string of the two character abbreviation of a US 
+#'     state (when applicable).}
+#'   \item{lat}{Latitude (degrees) rounded to three decimal places.}
+#'   \item{lon}{Longitude (degrees) rounded to three decimal places.}
+#'   \item{elev}{Numeric value for the elevation as measured in meters. 
+#'     The minimum value is -400 with a maximum of 8850. Elevation in feet
+#'     can be approximated by \code{elev * 3.28084}}
+#'   \item{begin}{The earliest year for which data are available.}
+#'   \item{end}{The latest year for which data are available.}
+#'   \item{gn_gmtoffset}{A time zone offset.}
+#'   \item{rawoffset}{A time zone offset.  I'm not entirely sure how this 
+#'     differs from \code{gn_gmtoffset}.}
+#'   \item{time_zone_id}{Time zone identifier}
+#'   \item{country_name}{Character string giving the name of the country 
+#'     where the station is located.}
+#'   \item{country_code}{A character string with the two character country 
+#'     code where the station is located.  This is not identical to the 
+#'     \code{country} column.  At first glance, this column appears to resemble
+#'     the country more accurately than \code{country}.}
+#' }
+#' 
+#' @source 
+#' \url{http://www.ncdc.noaa.gov/isd}\cr
+#' Source needed for column descriptions.
+#' 
 #' @examples
 #' \dontrun{
 #' # Obtain a data frame with all available met stations

--- a/R/select_isd_station.R
+++ b/R/select_isd_station.R
@@ -9,6 +9,13 @@
 #' should be returned.
 #' @param name the partial name of the station for which station data should 
 #' be returned.
+#' 
+#' @return Returns a data frame of ISD stations as documented in 
+#'   \code{\link{get_isd_stations}}.
+#'   
+#' @seealso
+#'   \code{\link{get_isd_stations}}
+#'   
 #' @examples 
 #' \dontrun{
 #' # Obtain a listing of all stations within a bounding box and

--- a/man/get_isd_station_data.Rd
+++ b/man/get_isd_station_data.Rd
@@ -3,6 +3,13 @@
 \name{get_isd_station_data}
 \alias{get_isd_station_data}
 \title{Get met station data from the ISD dataset}
+\source{
+\url{http://www.ncdc.noaa.gov/isd}\cr
+\url{http://www1.ncdc.noaa.gov/pub/data/ish/ish-format-document.pdf}
+
+Calculating Humidity: \cr
+\url{https://en.wikipedia.org/wiki/Clausius\%E2\%80\%93Clapeyron_relation#Meteorology_and_climatology}
+}
 \usage{
 get_isd_station_data(station_id, startyear, endyear)
 }
@@ -13,6 +20,60 @@ WBAN numbers, separated by a hyphen.}
 \item{startyear}{the starting year for the collected data.}
 
 \item{endyear}{the ending year for the collected data.}
+}
+\value{
+Returns a data frame with 19 variables.  Times are recorded
+using the Universal Time Code (UTC) in the source data.  Using
+\code{local_tz} adjusts the time zone to the current locale.
+\describe{
+  \item{usaf}{A character string identifying the fixed weather
+    station from the USAF Master Station Catalog.
+    USAF is an acronym for United States Air Force.}
+  \item{wban}{A character string for the fixed weather
+    station NCDC WBAN identifier.
+    NCDC is an acronym for National Climatic Data Center.
+    WBAN is an acronym for Weather Bureau, Air Force and Navy.}
+  \item{year}{A numeric, four digit value giving the year of the
+    observation.}
+  \item{month}{A numeric value (one or two digits) giving the month
+    of the observation.}
+  \item{day}{A numeric value (one or two digits) giving the day of the
+    month of the observation.}
+  \item{hour}{A numeric value (one or two digits) giving the hour of
+    the observation.}
+  \item{minute}{A numeric value (one or two digits) giving the minute
+    of the hour in which the observation was recorded.}
+  \item{lat}{Latitude (degrees) rounded to three decimal places.}
+  \item{lon}{Longitude (degrees) rounded to three decimal places.}
+  \item{elev}{Numeric value for the elevation as measured in meters.
+    The minimum value is -400 with a maximum of 8850. Elevation in feet
+    can be approximated by \code{elev * 3.28084}}
+  \item{wd}{The angle of wind direction, measured in a clockwise
+    direction, between true north and the direction from which
+    the wind is blowing.  For example, \code{wd = 90} indicates the
+    wind is blowing from due east.  \code{wd = 225} indicates the
+    wind is blowing from the south west.  The minimum value is 1, and the
+    maximum value is 360.}
+  \item{ws}{Wind speed in meters per second.  Wind speed in feet per
+    second can be estimated by \code{ws * 3.28084}}
+  \item{ceil_hgt}{The height above ground level of the lowest clould cover
+    or other obscuring phenomena amounting to at least 5/8 sky
+    coverate.  Measured in meters.  Unlimited height (no obstruction)
+    is denoted by the value 22000}
+  \item{temp}{Air temperature measured in degrees Celsius.  Conversions
+    to degrees Farenheit may be calculated with
+    \code{(temp * 9) / 5 + 32}}.
+  \item{dew_point}{The temperature in degrees Celsius to which a
+    given parcel of air must be cooled at constant pressure and
+    water vapor content in order for saturation to occur.}
+  \item{atmos_pres}{The air pressure in hectopascals relative to
+    Mean Sea Level (MSL)}
+  \item{rh}{Relative humidity, measured as a percentage,
+    as calculated using the August-Roche-Magnus approximation}
+  \item{time}{A POSIXct object with the date-time of the observation.}
+  \item{min}{The minute value of the observation.  This is a duplicate
+    of minute.}
+}
 }
 \description{
 Obtain one or more years of meteorological data for a station

--- a/man/get_isd_stations.Rd
+++ b/man/get_isd_stations.Rd
@@ -3,6 +3,10 @@
 \name{get_isd_stations}
 \alias{get_isd_stations}
 \title{Get listing of ISD stations based on location or time bounds}
+\source{
+\url{http://www.ncdc.noaa.gov/isd}\cr
+Source needed for column descriptions.
+}
 \usage{
 get_isd_stations(startyear = NULL, endyear = NULL, lower_lat = NULL,
   upper_lat = NULL, lower_lon = NULL, upper_lon = NULL)
@@ -19,6 +23,40 @@ get_isd_stations(startyear = NULL, endyear = NULL, lower_lat = NULL,
 \item{lower_lon}{the lower bound of the longitude for a bounding box.}
 
 \item{upper_lon}{the upper bound of the longitude for a bounding box.}
+}
+\value{
+Returns a data frame with 15 columns.
+\describe{
+  \item{usaf}{A character string identifying the fixed weather
+    station from the USAF Master Station Catalog.
+    USAF is an acronym for United States Air Force.}
+  \item{wban}{A character string for the fixed weather
+    station NCDC WBAN identifier.
+    NCDC is an acronym for National Climatic Data Center.
+    WBAN is an acronym for Weather Bureau, Air Force and Navy.}
+  \item{name}{A character string with the station name.}
+  \item{country}{A character string with the two character country
+    code where the station is located. Not identical to \code{country_code}.}
+  \item{state}{Character string of the two character abbreviation of a US
+    state (when applicable).}
+  \item{lat}{Latitude (degrees) rounded to three decimal places.}
+  \item{lon}{Longitude (degrees) rounded to three decimal places.}
+  \item{elev}{Numeric value for the elevation as measured in meters.
+    The minimum value is -400 with a maximum of 8850. Elevation in feet
+    can be approximated by \code{elev * 3.28084}}
+  \item{begin}{The earliest year for which data are available.}
+  \item{end}{The latest year for which data are available.}
+  \item{gn_gmtoffset}{A time zone offset.}
+  \item{rawoffset}{A time zone offset.  I'm not entirely sure how this
+    differs from \code{gn_gmtoffset}.}
+  \item{time_zone_id}{Time zone identifier}
+  \item{country_name}{Character string giving the name of the country
+    where the station is located.}
+  \item{country_code}{A character string with the two character country
+    code where the station is located.  This is not identical to the
+    \code{country} column.  At first glance, this column appears to resemble
+    the country more accurately than \code{country}.}
+}
 }
 \description{
 Obtain a data frame containing information on hourly

--- a/man/select_isd_station.Rd
+++ b/man/select_isd_station.Rd
@@ -16,6 +16,10 @@ should be returned.}
 \item{name}{the partial name of the station for which station data should
 be returned.}
 }
+\value{
+Returns a data frame of ISD stations as documented in
+  \code{\link{get_isd_stations}}.
+}
 \description{
 After filtering the list of global meteorological stations
 using \code{get_isd_stations} there may be several stations returned,
@@ -37,5 +41,8 @@ cypress_bowl_snowboard_stn <-
   select_isd_station(stn_df = stations_within_domain,
                      name = "cypress bowl snowboard")
 }
+}
+\seealso{
+\code{\link{get_isd_stations}}
 }
 


### PR DESCRIPTION
I've done my best to document the data that are returned.  I couldn't find a resource to describe the station data file, so I had to make some guesses there, and I'd read over the documentation for `get_isd_station`.  I wrote in the documentation those that I wasn't sure about.

It seems like the `country` and `country_code` should be the same, based on what information I have, but they clearly aren't.  `country_code` looks to be more accurate to me.  But again, that's based on a limited understanding of the data.  

I also added `lubridate` to the `DESCRIPTION` file so that I could run `check`.
